### PR TITLE
Change the include order

### DIFF
--- a/include/usb.h
+++ b/include/usb.h
@@ -11,8 +11,8 @@
 
 #include <stdint.h>
 #include <stdio.h>
-#include "fsl_common.h"
 #include "fsl_os_abstraction.h"
+#include "fsl_common.h"
 #include "usb_misc.h"
 #include "usb_spec.h"
 


### PR DESCRIPTION
Change the include order to avoid a warning during Zephyr compile. By including fsl_os_abstraction before fsl_common we can use the Zephyr defined utilities which would avoid this warning.
