### PR TITLE
Fix build failure when using the mcux-sdk-middleware-usb in Zephyr

### DIFF
--- a/middleware_usb_common_header.cmake
+++ b/middleware_usb_common_header.cmake
@@ -9,5 +9,3 @@ target_include_directories(${MCUX_SDK_PROJECT_NAME} PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/include
 )
 
-
-include(component_osa)


### PR DESCRIPTION
Fix build failure when compiling with Zephyr

Signed-off-by: Mahesh Mahadevan <mahesh.mahadevan@nxp.com>