### PR TITLE
Add start of frame notification for lpcip3511

### DIFF
--- a/device/usb_device_dci.h
+++ b/device/usb_device_dci.h
@@ -33,6 +33,7 @@ typedef enum _usb_device_notification
     kUSB_DeviceNotifyError,            /*!< Errors happened in bus */
     kUSB_DeviceNotifyDetach,           /*!< Device disconnected from a host */
     kUSB_DeviceNotifyAttach,           /*!< Device connected to a host */
+    kUSB_DeviceNotifySOF,              /*!< Start of Frame */
 #if (defined(USB_DEVICE_CONFIG_CHARGER_DETECT) && (USB_DEVICE_CONFIG_CHARGER_DETECT > 0U))
     kUSB_DeviceNotifyDcdDetectFinished, /*!< Device charger detection finished */
 #endif


### PR DESCRIPTION
#This enables the start of frame interrupt.  When a start of frame interrupt occurs, a message is created and sent via USB_DeviceNotificationTrigger.

Notifications are gated by the define USB_DEVICE_CONFIG_SOF_NOTIFICATIONS. Some upper layers that use this middleware need start of frame notifications for doing isochronous transfers.

This fixes the following issue:
#7 