### PR TITLE
device: use SDK_DelayAtLeastUs method to perform wakeup delay instead of hwTick

### DIFF
--- a/device/usb_device_ehci.c
+++ b/device/usb_device_ehci.c
@@ -2021,11 +2021,7 @@ usb_status_t USB_DeviceEhciControl(usb_device_controller_handle ehciHandle, usb_
 #endif
             ehciState->registerBase->PORTSC1 &= ~USBHS_PORTSC1_PHCD_MASK;
             ehciState->registerBase->PORTSC1 |= USBHS_PORTSC1_FPR_MASK;
-            startTick = deviceHandle->hwTick;
-            while ((deviceHandle->hwTick - startTick) < 10U)
-            {
-                __NOP();
-            }
+            SDK_DelayAtLeastUs(5000, SystemCoreClock);
             ehciState->registerBase->PORTSC1 &= ~USBHS_PORTSC1_FPR_MASK;
             error = kStatus_USB_Success;
             break;

--- a/device/usb_device_khci.c
+++ b/device/usb_device_khci.c
@@ -1623,11 +1623,7 @@ usb_status_t USB_DeviceKhciControl(usb_device_controller_handle khciHandle, usb_
 #if defined(USB_DEVICE_CONFIG_REMOTE_WAKEUP) && (USB_DEVICE_CONFIG_REMOTE_WAKEUP > 0U)
         case kUSB_DeviceControlResume:
             khciState->registerBase->CTL |= USB_CTL_RESUME_MASK;
-            startTick = deviceHandle->hwTick;
-            while ((deviceHandle->hwTick - startTick) < 10U)
-            {
-                __NOP();
-            }
+            SDK_DelayAtLeastUs(5000, SystemCoreClock);
             khciState->registerBase->CTL &= (uint8_t)(~USB_CTL_RESUME_MASK);
             status = kStatus_USB_Success;
             break;


### PR DESCRIPTION
This makes the use of hwTick unnecessary in device mode (excluding the more exotic use cases).

The delay itself is also reduced, the USB spec requires a delay between 1 and 15 ms, the previous 10 is now brought down to 5. I'm open to setting this to another value if required.